### PR TITLE
Prefer PECL Yaml over Symfony's Yaml Parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "mikey179/vfsStream": "^1.6"
     },
     "suggest": {
+        "ext-yaml": "For improved performance when parsing yaml files you should use the PECL YAML Parser php extension",
         "symfony/yaml": "To be able to parse yaml files, you will need symfony/yaml"
     },
     "autoload": {

--- a/src/ConfigurationReaderFactory.php
+++ b/src/ConfigurationReaderFactory.php
@@ -16,6 +16,7 @@ use Helhum\ConfigLoader\Reader\ConfigReaderInterface;
 use Helhum\ConfigLoader\Reader\EnvironmentReader;
 use Helhum\ConfigLoader\Reader\GlobFileReader;
 use Helhum\ConfigLoader\Reader\NestedConfigReader;
+use Helhum\ConfigLoader\Reader\PeclYamlFileReader;
 use Helhum\ConfigLoader\Reader\PhpFileReader;
 use Helhum\ConfigLoader\Reader\RootConfigFileReader;
 use Helhum\ConfigLoader\Reader\YamlFileReader;
@@ -70,6 +71,9 @@ class ConfigurationReaderFactory
             ],
             'yaml' => [
                 'factory' => function (string $resource) {
+                    if (extension_loaded('yaml')) {
+                        return new PeclYamlFileReader($resource);
+                    }
                     return new YamlFileReader($resource);
                 },
                 'isFileResource' => true,

--- a/src/Reader/PeclYamlFileReader.php
+++ b/src/Reader/PeclYamlFileReader.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\ConfigLoader\Reader;
+
+/*
+ * This file is part of the helhum configuration loader package.
+ *
+ * (c) Helmut Hummel <info@helhum.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Helhum\ConfigLoader\InvalidConfigurationFileException;
+
+/**
+ * Yaml file reader based on pecl PHP extension
+ */
+class PeclYamlFileReader implements ConfigReaderInterface
+{
+    /**
+     * @var string
+     */
+    private $configFile;
+
+    public function __construct(string $configFile)
+    {
+        $this->configFile = $configFile;
+    }
+
+    public function hasConfig(): bool
+    {
+        return file_exists($this->configFile);
+    }
+
+    public function readConfig(): array
+    {
+        $config = null;
+
+        set_error_handler(function ($_, $errorMessage) {
+            throw new InvalidConfigurationFileException($errorMessage, 1518628276);
+        });
+        try {
+            $config = yaml_parse_file($this->configFile);
+        } catch (InvalidConfigurationFileException $e) {
+            throw new InvalidConfigurationFileException(sprintf('Error while parsing file "%s", Message: "%s"', $this->configFile, $e->getMessage()), 1518629212, $e);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!is_array($config)) {
+            throw new InvalidConfigurationFileException(sprintf('Configuration file "%s" is invalid. It must return an array, but returned "%s"', $this->configFile, gettype($config)), 1518627396);
+        }
+        return $config;
+    }
+}

--- a/src/Reader/YamlFileReader.php
+++ b/src/Reader/YamlFileReader.php
@@ -15,6 +15,9 @@ use Helhum\ConfigLoader\InvalidConfigurationFileException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * Yaml file reader based on Symfony Yaml parser
+ */
 class YamlFileReader implements ConfigReaderInterface
 {
     /**

--- a/tests/Unit/Fixture/conf/broken_string.yml
+++ b/tests/Unit/Fixture/conf/broken_string.yml
@@ -1,0 +1,5 @@
+meta:
+  description: This file fails the standard yaml parsing
+  failing:
+    string: %someFunctionCall()%
+    explanation: 'The % character is an unknown character for the pecl YAML parser. If you want to use it, you should wrap it in quotes.'

--- a/tests/Unit/Fixture/conf/production.yml
+++ b/tests/Unit/Fixture/conf/production.yml
@@ -5,3 +5,4 @@ override_key: production
 nested:
     foo:
         bla: blupp
+        str: '%bar(baz)%'

--- a/tests/Unit/Reader/PeclYamlFileReaderTest.php
+++ b/tests/Unit/Reader/PeclYamlFileReaderTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\ConfigLoader\Tests\Reader;
+
+/*
+ * This file is part of the helhum TYPO3 configuration loader package.
+ *
+ * (c) Helmut Hummel <info@helhum.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Helhum\ConfigLoader\InvalidConfigurationFileException;
+use Helhum\ConfigLoader\Reader\PeclYamlFileReader;
+
+class PeclYamlFileReaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('yaml')) {
+            $this->markTestSkipped('Not able to test pecl yaml reader without pecl yaml extension being installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function configIsNestedInGivenPath()
+    {
+        $reader = new PeclYamlFileReader(dirname(__DIR__) . '/Fixture/conf/broken_string.yml');
+        $this->expectException(InvalidConfigurationFileException::class);
+        $this->expectExceptionCode(1518629212);
+        $reader->readConfig();
+    }
+}


### PR DESCRIPTION
Update the `YamlFileReader` to prefer the PECL Yaml extension when loaded over Symfony's Yaml Parser.

The pecl extesion uses the [LibYaml](https://github.com/yaml/libyaml) C library which is much faster than the Symfony Yaml parser which is written in PHP (compare https://github.com/koenpunt/yaml-php-benchmark).

**Note:** This library is using along with https://github.com/helhum/typo3-config-handling in your https://github.com/helhum/TYPO3-Distribution. After merging the configuration files the yaml parsing through the PECL Yaml extension might fail because of _invalid characters_. You need to update the configurations in the TYPO3-Distribution and wrap the string in https://github.com/helhum/TYPO3-Distribution/blob/master/conf/dev.config.yml#L25 in quotes.